### PR TITLE
Add docs for C and C++ client drivers for YSQL

### DIFF
--- a/content/latest/develop/client-drivers/c.md
+++ b/content/latest/develop/client-drivers/c.md
@@ -1,0 +1,46 @@
+---
+title: C
+linkTitle: C
+description: Develop C Apps
+aliases:
+  - /develop/client-drivers/c/
+menu:
+  latest:
+    identifier: client-drivers-c
+    parent: client-drivers
+    weight: 550
+---
+
+<ul class="nav nav-tabs nav-tabs-yb">
+  <li>
+    <a href="#cql" class="nav-link active" id="cql-tab" data-toggle="tab" role="tab" aria-controls="cql" aria-selected="true">
+      <i class="icon-cassandra" aria-hidden="true"></i>
+      YCQL
+    </a>
+  </li>
+  <li>
+    <a href="#redis" class="nav-link" id="redis-tab" data-toggle="tab" role="tab" aria-controls="redis" aria-selected="false">
+      <i class="icon-redis" aria-hidden="true"></i>
+      YEDIS
+    </a>
+  </li>
+  <li>
+    <a href="#ysql" class="nav-link" id="ysql-tab" data-toggle="tab" role="tab" aria-controls="ysql" aria-selected="false">
+      <i class="icon-ysql" aria-hidden="true"></i>
+      YSQL
+    </a>
+  </li>
+</ul>
+
+<div class="tab-content">
+  <div id="cql" class="tab-pane fade show active" role="tabpanel" aria-labelledby="cql-tab">
+    {{% includeMarkdown "cassandra/cpp.md" /%}}
+  </div>
+  <div id="redis" class="tab-pane fade" role="tabpanel" aria-labelledby="redis-tab">
+    {{% includeMarkdown "redis/cpp.md" /%}}
+  </div>
+  <div id="ysql" class="tab-pane fade" role="tabpanel" aria-labelledby="ysql-tab">
+    {{% includeMarkdown "ysql/c.md" /%}}
+  </div>
+</div>
+

--- a/content/latest/develop/client-drivers/cpp.md
+++ b/content/latest/develop/client-drivers/cpp.md
@@ -1,7 +1,7 @@
 ---
-title: C/C++
-linkTitle: C/C++
-description: Develop C/C++ Apps
+title: C++
+linkTitle: C++
+description: Develop C++ Apps
 aliases:
   - /develop/client-drivers/cpp/
 menu:
@@ -24,6 +24,12 @@ menu:
       YEDIS
     </a>
   </li>
+  <li>
+    <a href="#ysql" class="nav-link" id="ysql-tab" data-toggle="tab" role="tab" aria-controls="ysql" aria-selected="false">
+      <i class="icon-ysql" aria-hidden="true"></i>
+      YSQL
+    </a>
+  </li>
 </ul>
 
 <div class="tab-content">
@@ -32,6 +38,9 @@ menu:
   </div>
   <div id="redis" class="tab-pane fade" role="tabpanel" aria-labelledby="redis-tab">
     {{% includeMarkdown "redis/cpp.md" /%}}
+  </div>
+  <div id="ysql" class="tab-pane fade" role="tabpanel" aria-labelledby="ysql-tab">
+    {{% includeMarkdown "ysql/cpp.md" /%}}
   </div>
 </div>
 

--- a/content/latest/develop/client-drivers/ysql/c.md
+++ b/content/latest/develop/client-drivers/ysql/c.md
@@ -5,14 +5,14 @@ The tutorial assumes that you have:
 
 - installed YugaByte DB, and created a universe with YSQL enabled. If not, please follow these steps in the [quick start guide](../../../quick-start/test-ysql).
 - have a 32-bit (x86) or 64-bit (x64) architecture machine.
-- have gcc 4.1.2+ or Clang 3.4+ installed.
+- have gcc 4.1.2+, clang 3.4+ installed.
 
 ## Installing the C Driver (libpq)
 
 The C driver is already available as part of the YugaByte installation. You can use it by setting the LD_LIBRARY_PATH as follows :- 
   
 ```sh
-$ export LD_LIBRARY_PATH=<yugabyte-install-dir>/build/latest/postgres/lib
+$ export LD_LIBRARY_PATH=<yugabyte-install-dir>/postgres/lib
 ```
 
 Alternatively, you can download the postgres binaries or build the driver from source as documented [here](https://www.postgresql.org/download/).
@@ -116,7 +116,7 @@ You can compile the file using gcc or clang.
 For gcc, you can use:
 
 ```sh
-$ gcc ybsql_hello_world.c -lpq -I<yugabyte-install-dir>/build/latest/postgres/include -o ybsql-hello_world
+$ gcc ybsql_hello_world.c -lpq -I<yugabyte-install-dir>/postgres/include -o ybsql_hello_world
 ```
 
 Run with:

--- a/content/latest/develop/client-drivers/ysql/c.md
+++ b/content/latest/develop/client-drivers/ysql/c.md
@@ -1,0 +1,134 @@
+
+## Pre-requisites
+
+The tutorial assumes that you have:
+
+- installed YugaByte DB, and created a universe with YSQL enabled. If not, please follow these steps in the [quick start guide](../../../quick-start/test-ysql).
+- have a 32-bit (x86) or 64-bit (x64) architecture machine.
+- have gcc 4.1.2+ or Clang 3.4+ installed.
+
+## Installing the C Driver (libpq)
+
+The C driver is already available as part of the YugaByte installation. You can use it by setting the LD_LIBRARY_PATH as follows :- 
+  
+```sh
+$ export LD_LIBRARY_PATH=<yugabyte-install-dir>/build/latest/postgres/lib
+```
+
+Alternatively, you can download the postgres binaries or build the driver from source as documented [here](https://www.postgresql.org/download/).
+
+## Working Example
+
+### Writing the C Code.
+
+Create a file `ybsql_hello_world.c` and copy the contents below:
+
+```cpp
+#include <stdio.h>
+#include <stdlib.h>
+#include "libpq-fe.h"
+
+int
+main(int argc, char **argv)
+{
+  const char *conninfo;
+  PGconn     *conn;
+  PGresult   *res;
+  int         nFields;
+  int         i, j;
+
+  /* connection string */
+  conninfo = "host=127.0.0.1 port=5433 dbname=postgres user=postgres password=postgres";
+
+  /* Make a connection to the database */
+  conn = PQconnectdb(conninfo);
+
+  /* Check to see that the backend connection was successfully made */
+  if (PQstatus(conn) != CONNECTION_OK)
+  {
+      fprintf(stderr, "Connection to database failed: %s",
+	      PQerrorMessage(conn));
+      PQfinish(conn);
+      exit(1);
+  }
+
+  /* Create table */
+  res = PQexec(conn, "CREATE TABLE employee (id int PRIMARY KEY, \
+                                             name varchar, age int, \
+                                             language varchar)");
+
+  if (PQresultStatus(res) != PGRES_COMMAND_OK)
+  {
+      fprintf(stderr, "CREATE TABLE failed: %s", PQerrorMessage(conn));
+      PQclear(res);
+      PQfinish(conn);
+      exit(1);
+  }
+  PQclear(res);
+  printf("Created table employee\n");
+
+  /* Insert a row */
+  res = PQexec(conn, "INSERT INTO employee (id, name, age, language) \
+                      VALUES (1, 'John', 35, 'C')");
+
+  if (PQresultStatus(res) != PGRES_COMMAND_OK)
+  {
+      fprintf(stderr, "INSERT failed: %s", PQerrorMessage(conn));
+      PQclear(res);
+      PQfinish(conn);
+      exit(1);
+  }
+  PQclear(res);
+  printf("Inserted data (1, 'John', 35, 'C')\n");
+
+
+  /* Query the row */
+  res = PQexec(conn, "SELECT name, age, language FROM employee WHERE id = 1");
+  if (PQresultStatus(res) != PGRES_TUPLES_OK)
+  {
+      fprintf(stderr, "SELECT failed: %s", PQerrorMessage(conn));
+      PQclear(res);
+      PQfinish(conn);
+      exit(1);
+  }
+
+  /* print out the rows */
+  nFields = PQnfields(res);
+  for (i = 0; i < PQntuples(res); i++)
+  {
+      printf("Query returned: ");
+      for (j = 0; j < nFields; j++)
+	printf("%s ", PQgetvalue(res, i, j));
+      printf("\n");
+  }
+  PQclear(res);
+
+  /* close the connection to the database and cleanup */
+  PQfinish(conn);
+
+  return 0;
+}
+```
+
+### Running the application
+
+You can compile the file using gcc or clang. 
+For gcc, you can use:
+
+```sh
+$ gcc ybsql_hello_world.c -lpq -I<yugabyte-install-dir>/build/latest/postgres/include -o ybsql-hello_world
+```
+
+Run with:
+
+```sh
+$ ./ybsql_hello_world
+```
+
+You should see the following output:
+
+```
+Created table employee
+Inserted data (1, 'John', 35, 'C')
+Query returned: John 35 C 
+```

--- a/content/latest/develop/client-drivers/ysql/cpp.md
+++ b/content/latest/develop/client-drivers/ysql/cpp.md
@@ -1,0 +1,124 @@
+
+## Pre-requisites
+
+The tutorial assumes that you have:
+
+- installed YugaByte DB, and created a universe with YSQL enabled. If not, please follow these steps in the [quick start guide](../../../quick-start/test-ysql).
+- have a 32-bit (x86) or 64-bit (x64) architecture machine.
+- have gcc 4.1.2+, clang 3.4+ installed.
+
+## Installing the C++ Driver (libpqxx)
+
+Download the source from [here](https://github.com/jtv/libpqxx) and build the binaries as follows. Detailed instructions are provided [here](https://github.com/jtv/libpqxx).
+
+### Getting the source 
+
+```sh
+$ git clone https://github.com/jtv/libpqxx.git
+```
+
+### Dependencies 
+
+Note that this package depends on pg binaries. Make sure that postgres bin directory is on the command path.
+
+```sh
+export PATH=$PATH:<yugabyte-install-dir>/postgres/bin
+```
+
+### Build and Install
+
+```sh
+$ cd libpqxx
+$ ./configure
+$ make
+$ make install
+```
+
+## Working Example
+
+### Writing the C++ Code.
+
+Create a file `ybsql_hello_world.cpp` and copy the contents below:
+
+```cpp
+#include <iostream>
+#include <pqxx/pqxx>
+
+int main(int, char *argv[])
+{
+  pqxx::connection c("host=127.0.0.1 port=5433 dbname=postgres user=postgres password=postgres");
+  pqxx::work txn(c);
+  pqxx::result r;
+
+  /* Create table */
+  try 
+  {
+    r = txn.exec("CREATE TABLE employee (id int PRIMARY KEY, \
+                  name varchar, age int, \
+                  language varchar)");
+  }
+  catch (const std::exception &e)
+  {
+    std::cerr << e.what() << std::endl;
+    return 1;
+  }
+
+  std::cout << "Created table employee\n";
+
+  /* Insert a row */
+  try 
+  {
+    r = txn.exec("INSERT INTO employee (id, name, age, language) \
+                  VALUES (1, 'John', 35, 'C++')");
+  }
+  catch (const std::exception &e)
+  {
+    std::cerr << e.what() << std::endl;
+    return 1;
+  }
+
+  std::cout << "Inserted data (1, 'John', 35, 'C++')\n";
+
+  /* Query the row */
+  try 
+  {
+    r = txn.exec("SELECT name, age, language FROM employee WHERE id = 1");
+
+    for (auto row: r)
+      std::cout << "Query returned: " 
+          << row["name"].c_str() << ", "
+          << row["age"].as<int>() << ", "
+          << row["language"].c_str() << std::endl;
+  }
+  catch (const std::exception &e)
+  {
+    std::cerr << e.what() << std::endl;
+    return 1;
+  }
+
+  txn.commit();
+  return 0;
+}
+```
+
+### Running the application
+
+You can compile the file using gcc or clang. Note that C++11 is the minimum supported C++ version. Make sure your compiler supports this, and if necessary, that you have support for C++11 configured. For gcc, you can use:
+
+```sh
+$ g++ -std=c++11 ybsql_hello_world.cpp -lpqxx -lpq -I<yugabyte-install-dir>/postgres/include -o ybsql_hello_world
+```
+
+Run with:
+
+```sh
+$ ./ybsql_hello_world
+```
+
+You should see the following output:
+
+```
+Created table employee
+Inserted data (1, 'John', 35, 'C++')
+Query returned: John, 35, C++ 
+```


### PR DESCRIPTION
Added docs for C and C++ client drivers for YSQL.
Created a new "C" section. For YCQL and YEDIS, the C section simply points the corresponding C++ docs. However for YSQL, the C doc (for using libpq) is different from its C++ doc (for using libpqxx).
