### PR TITLE
#17: Add UUID built in info in API reference.

### DIFF
--- a/content/latest/api/ycql/expr_fcall.md
+++ b/content/latest/api/ycql/expr_fcall.md
@@ -45,6 +45,7 @@ function_call ::= function_name '(' [ arguments ... ] ')'
 | [ToUnixTimestamp](../function_datetime/#tounixtimestamp) | [`BIGINT`](../type_int) | ([`TIMESTAMP`](../type_datetime))  | Conversion |
 | [ToUnixTimestamp](../function_datetime/#tounixtimestamp) | [`BIGINT`](../type_int) | ([`TIMEUUID`](../type_uuid)) | Conversion |
 | [UnixTimestampOf](../function_datetime/#unixtimestampof) | [`BIGINT`](../type_int) | ([`TIMEUUID`](../type_uuid)) | Conversion |
+| [UUID](../function_datetime/#uuid) | [`UUID`](../type_uuid) | () | Returns a version 4 UUID |
 | WriteTime | [`BIGINT`](../type_int) | (<AnyType>) | Returns the time when the column was written |
 
 ## Aggregate Functions

--- a/content/latest/api/ycql/function_datetime.md
+++ b/content/latest/api/ycql/function_datetime.md
@@ -291,6 +291,48 @@ cqlsh:example> SELECT v from test_unixtimestampof WHERE v < unixtimestampof(now(
  1525474356781
 ```
 
+## uuid()
+
+This function generates a new unique version 4 UUID (`UUID`).
+
+- It takes in no arguments.
+- The return value is a `UUID`.
+
+### Examples
+
+#### Insert values using uuid()
+
+```sql
+cqlsh:example> CREATE TABLE test_uuid (k INT PRIMARY KEY, v UUID);
+```
+
+```sql
+cqlsh:example> INSERT INTO test_uuid (k, v) VALUES (1, uuid());
+```
+
+#### Selecting the inserted uuid value
+
+```sql
+cqlsh:example> SELECT v FROM test_uuid WHERE k = 1;
+
+```
+ v
+---------------------------------------
+ 71bb5104-4fe9-11e8-8839-6336e659252a
+```
+
+#### Select using uuid()
+
+```sql
+cqlsh:example> SELECT uuid() FROM test_uuid;
+```
+
+```
+ uuid()
+--------------------------------------
+ 12f91a52-ebba-4461-94c5-b73f0914284a
+```
+
 ## See Also
 
 [`DATE`, `TIME` and `TIMESTAMP`](../type_datetime)

--- a/content/latest/deploy/manual-deployment/start-masters.md
+++ b/content/latest/deploy/manual-deployment/start-masters.md
@@ -14,7 +14,8 @@ showAsideToc: true
 ---
 
 {{< note title="Note" >}}
-For any cluster, the number of nodes on which the YB-Masters need to be started on **must** equal the replication factor.
+- For any cluster, the number of nodes on which the YB-Masters need to be started on **must** equal the replication factor.
+- The number of comma seperated addresses present in `master_addresses` should also equal the replication factor.
 {{< /note >}}
 
 ## Example Scenario

--- a/content/latest/deploy/manual-deployment/start-tservers.md
+++ b/content/latest/deploy/manual-deployment/start-tservers.md
@@ -38,6 +38,10 @@ $ ./bin/yb-tserver \
   >& /home/centos/disk1/yb-tserver.out &
 ```
 
+{{< note title="Note" >}}
+The number of comma seperated values in `tserver_master_addrs` parameter should match the total number of masters (aka replication factor).
+{{< /note >}}
+
 ## Run yb-tserver with conf file
 
 - Alternatively, you can also create a `tserver.conf` file with the following flags and then run the `yb-tserver` with the `--flagfile` option as shown below.

--- a/content/latest/manage/enterprise-edition/node-actions.md
+++ b/content/latest/manage/enterprise-edition/node-actions.md
@@ -133,3 +133,10 @@ In the worst case scenario, when the system runs into some unrecoverable errors 
 As a summary of all the actions that were run on this universe, one can check the 'Tasks' tab to see the remove/add and stop/start tasks that were run on that universe.
 
 ![Tasks Node Actions](/images/ee/node-actions-tasks.png)
+
+{{< note title="Note" >}}
+In any universe, one cannot have more than (RF - 1)/2 `Master` nodes in `Stop` or `Remove` status at the same time.
+{{< /note >}}
+
+## Interaction with other operations
+If there is a node in any of the in-transit states of `Stopped`, `Removed` or `Decommissioned` in the universe, we disallow [edit operations](manage/enterprise-edition/edit-universe/) and [rolling upgrade operations](latest/manage/enterprise-edition/upgrade-universe/). These operations are allowed once such a node comes out of that in-transit state.


### PR DESCRIPTION
Includes:
- UUID built-in info.
- Notes about master/tserver startup regarding number of masters in the gflag matching replication factor.
- Added notes to node actions section.
