### PR TITLE
Fix when clicking on section on page causing page to jump

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -189,10 +189,11 @@ $(document).ready(() => {
 
 $(() => {
   const hash = window.location.hash;
-  if (hash) $('ul.nav-tabs-yb a[href="' + hash + '"]').tab('show');
+  if (hash) {
+    $('ul.nav-tabs-yb a[href="' + hash + '"]').tab('show');
+  }
   $('.nav-tabs-yb a').click(function () {
     $(this).tab('show');
-    window.location.hash = this.hash;
   });
 });
 


### PR DESCRIPTION
Fixes #101 
Setting the `window.location.hash` is causing the page to appear to jump to a section. Removing that should fix the issue. The side effect of this is that it will not update the url with the section value (this would happen on the quick-start/install page).