### PR TITLE
Fix ordering of versions in dropdown menu and add note for earlier versions

### DIFF
--- a/layouts/partials/version_switcher.html
+++ b/layouts/partials/version_switcher.html
@@ -14,13 +14,16 @@
   {{ $currentVersion := (.Scratch.Get "currentVersionTitle") }}
 {{ end }} 
 {{ if gt (len (where (readDir (relURL "content/")) ".IsDir" "ne" false)) 1 }}
+  {{ $versions := where (readDir (relURL "content/")) ".IsDir" "ne" false }}
 <div class="dropdown" id="version-switcher">
     <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         {{ $currentVersion }}
     </button>
+    
     <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
-        {{ range where (readDir (relURL "content/")) ".IsDir" "ne" false}}
-            <a class="dropdown-item" href="/{{.Name}}/">{{ .Name }}</a>
+        <a class="dropdown-item" href="/latest/">{{ (index $versions 0).Name }}</a>
+        {{ range sort (after 1 $versions) "Name" "desc" }}
+            <a class="dropdown-item" href="/{{.Name}}/">{{ .Name }} (earlier version)</a>
         {{ end }}
     </div>
   </div>


### PR DESCRIPTION
Fixes #105 
Output:
<img width="668" alt="Screen Shot 2019-06-05 at 2 00 43 PM" src="https://user-images.githubusercontent.com/50115930/58990273-5eff1700-879a-11e9-8b60-507dc2f65d26.png">
