### PR TITLE
Fix FontAwesome checkmark icon for the copy button for code snippets

### DIFF
--- a/styles/_toc.scss
+++ b/styles/_toc.scss
@@ -88,8 +88,9 @@ pre code.copy + textarea + button.copy, .copy pre code + textarea + button.copy,
     position: absolute;
     top: 0;
     left: 0;    
-    font: normal normal normal 18px/1 FontAwesome;
-    content: '\F00C';
+    font: normal normal normal 18px/1 'Font Awesome 5 Free';
+    font-weight: 900;
+    content: '\f00c';
     color: #fff;
     text-align: center;
     border-radius: 2px;

--- a/styles/_yuga_content.scss
+++ b/styles/_yuga_content.scss
@@ -43,7 +43,8 @@
         list-style-type: none;
         &:before {
           content: '\f067';
-          font-family: 'FontAwesome';
+          font-family: 'Font Awesome 5 Free';
+          font-weight: 900;
           font-size: 13px;
           background-color: transparent;
           border: none;


### PR DESCRIPTION
Current:
<img width="120" alt="Screen Shot 2019-06-20 at 1 15 37 PM" src="https://user-images.githubusercontent.com/50115930/59878882-47a95780-935e-11e9-9491-12c83185a6c3.png">

Fix:
<img width="123" alt="Screen Shot 2019-06-20 at 1 15 48 PM" src="https://user-images.githubusercontent.com/50115930/59878935-67408000-935e-11e9-8246-711f0598c76f.png">
